### PR TITLE
moving seed into config struct

### DIFF
--- a/config.go
+++ b/config.go
@@ -38,6 +38,7 @@ type Config struct {
 	maxActorCount        int
 	workerPrefix         string
 	SleepAfterProcessing time.Duration
+	Seed                 int
 }
 
 func NewConfig() *Config {
@@ -118,6 +119,11 @@ func (c *Config) WithMaxActorCount(actors int) *Config {
 
 func (c *Config) WithPrefix(id string) *Config {
 	c.workerPrefix = id
+	return c
+}
+
+func (c *Config) WithSeed(seed int) *Config {
+	c.Seed = seed
 	return c
 }
 

--- a/dynamic.go
+++ b/dynamic.go
@@ -100,7 +100,7 @@ func (m *Manager) Start(ctx context.Context) error {
 		m.logger.Error("could not bootstrap config", "error", err)
 		return err
 	}
-	m.internalClient = NewClient(m.config, 0)
+	m.internalClient = NewClient(m.config)
 	m.actors, m.ctx = errgroup.WithContext(ctx)
 	m.actors.Go(func() error {
 		if err := m.Loop(m.ctx); err != nil {
@@ -150,8 +150,9 @@ func (m *Manager) Loop(ctx context.Context) error {
 							WithStreamArn(m.config.StreamARN).
 							WithTableName(m.config.ReservationTable).
 							WithRenewTime(m.config.RenewTime).
-							WithReservationTimeout(m.config.ReservationTimeout)
-						client := NewClient(cfg, index)
+							WithReservationTimeout(m.config.ReservationTimeout).
+							WithSeed(index)
+						client := NewClient(cfg)
 						err := client.Init(ctx)
 						if err != nil {
 							if errors.Is(err, ErrShardReserved) {

--- a/dynamic_test.go
+++ b/dynamic_test.go
@@ -31,7 +31,7 @@ func TestNew(t *testing.T) {
 
 func TestActorWork_NoReservation(t *testing.T) {
 	config := testConfig()
-	cl := NewClient(config, 0)
+	cl := NewClient(config)
 	a := Actor{
 		id: "test",
 		mc: cl,
@@ -106,7 +106,7 @@ func TestManager_LoopNoShards(t *testing.T) {
 	config := testConfig().WithKinesisClient(kc).WithDynamoClient(dc)
 	config.MangerLoopWaitTime = 100 * time.Millisecond
 	m := New(context.Background(), config)
-	m.internalClient = NewClient(config, 0)
+	m.internalClient = NewClient(config)
 	kc.EXPECT().DescribeStream(ctx, &kinesis.DescribeStreamInput{
 		StreamARN: aws.String("arn"),
 	}).
@@ -161,7 +161,7 @@ func TestManager_LoopAvailableShard(t *testing.T) {
 		return nil
 	}
 	m := New(context.Background(), config)
-	m.internalClient = NewClient(config, 0)
+	m.internalClient = NewClient(config)
 
 	// mock get available shards
 	kc.EXPECT().DescribeStream(ctx, &kinesis.DescribeStreamInput{

--- a/dynamo_test.go
+++ b/dynamo_test.go
@@ -24,7 +24,7 @@ func TestListReservations(t *testing.T) {
 	m := NewClient(NewConfig().
 		WithTableName("metamorphosis_reservations").
 		WithDynamoClient(dc).
-		WithGroup("testGroup"), 0)
+		WithGroup("testGroup"))
 
 	must.True(t, t.Run("happy path", func(t *testing.T) {
 		dc.EXPECT().Query(context.Background(), &dynamodb.QueryInput{
@@ -98,7 +98,7 @@ func TestCommitRecord(t *testing.T) {
 	dc := mocks.NewDynamoDBAPI(t)
 	config := testConfig().WithDynamoClient(dc)
 	expires := now.Add(config.ReservationTimeout)
-	m := NewClient(config, 0)
+	m := NewClient(config)
 	input := &dynamodb.UpdateItemInput{
 		TableName: &config.ReservationTable,
 		Key: map[string]types.AttributeValue{

--- a/integration_test.go
+++ b/integration_test.go
@@ -299,7 +299,7 @@ func defaultClient(workerID string) *Client {
 		WithDynamoClient(buildDynamoClient()).
 		WithKinesisClient(buildKinesisClient())
 
-	return NewClient(config, 0)
+	return NewClient(config)
 }
 
 func buildDynamoClient() DynamoDBAPI {

--- a/kinesis_test.go
+++ b/kinesis_test.go
@@ -23,7 +23,7 @@ func TestGetShardIterator(t *testing.T) {
 	must.True(t, t.Run("missing reservation", func(t *testing.T) {
 		kc := mocks.NewKinesisAPI(t)
 		config := testConfig().WithKinesisClient(kc)
-		m := NewClient(config, 0)
+		m := NewClient(config)
 
 		iterator, err := m.getShardIterator(context.Background())
 		must.Nil(t, iterator)
@@ -32,7 +32,7 @@ func TestGetShardIterator(t *testing.T) {
 	must.True(t, t.Run("after sequence", func(t *testing.T) {
 		kc := mocks.NewKinesisAPI(t)
 		config := testConfig().WithKinesisClient(kc)
-		m := NewClient(config, 0)
+		m := NewClient(config)
 		m.reservation = &Reservation{
 			LatestSequence: "last",
 		}
@@ -54,7 +54,7 @@ func TestGetShardIterator(t *testing.T) {
 	must.True(t, t.Run("trim horizon", func(t *testing.T) {
 		kc := mocks.NewKinesisAPI(t)
 		config := testConfig().WithKinesisClient(kc)
-		m := NewClient(config, 0)
+		m := NewClient(config)
 		m.reservation = &Reservation{
 			LatestSequence: "",
 		}
@@ -75,7 +75,7 @@ func TestGetShardIterator(t *testing.T) {
 	must.True(t, t.Run("kinesis error", func(t *testing.T) {
 		kc := mocks.NewKinesisAPI(t)
 		config := testConfig().WithKinesisClient(kc)
-		m := NewClient(config, 0)
+		m := NewClient(config)
 		m.reservation = &Reservation{
 			LatestSequence: "",
 		}
@@ -97,7 +97,7 @@ func TestGetShardIterator(t *testing.T) {
 func TestPutRecords(t *testing.T) {
 	kc := mocks.NewKinesisAPI(t)
 	config := testConfig().WithKinesisClient(kc)
-	m := NewClient(config, 0)
+	m := NewClient(config)
 	record := &metamorphosisv1.Record{
 		Id:   "partitionKey",
 		Body: []byte(`{"test":"json"}`),
@@ -125,7 +125,7 @@ func TestFetchRecords(t *testing.T) {
 	kc := mocks.NewKinesisAPI(t)
 	dc := mocks.NewDynamoDBAPI(t)
 	config := testConfig().WithKinesisClient(kc).WithDynamoClient(dc)
-	m := NewClient(config, 0)
+	m := NewClient(config)
 
 	dc.EXPECT().GetItem(ctx, &dynamodb.GetItemInput{
 		TableName: aws.String("table"),

--- a/metamorphosis.go
+++ b/metamorphosis.go
@@ -25,16 +25,13 @@ type Client struct {
 	// internal fields
 	config      *Config
 	reservation *Reservation
-	seed        int
 	logger      *slog.Logger
 }
 
-func NewClient(config *Config, seed int) *Client {
-	slog.Info("setting up client", "seed", seed)
+func NewClient(config *Config) *Client {
 	return &Client{
-		seed:   seed,
 		config: config,
-		logger: config.logger.With("seed", seed, "worker", config.WorkerID, "group", config.GroupID),
+		logger: config.logger.With("seed", config.Seed, "worker", config.WorkerID, "group", config.GroupID),
 	}
 }
 func (c *Client) Init(ctx context.Context) error {
@@ -71,9 +68,11 @@ func (m *Client) retrieveRandomShardID(ctx context.Context) (string, error) {
 	}
 	shards := output.Shards
 	shardSize := len(shards)
+
+	seed := m.config.Seed
 	// Find first unreserved shard
 	for i := range shards {
-		index := m.seed + i
+		index := seed + i
 		if index > shardSize-1 {
 			index = index - shardSize
 		}

--- a/metamorphosis_test.go
+++ b/metamorphosis_test.go
@@ -41,7 +41,7 @@ func TestInit_InvalidConfig(t *testing.T) {
 		logger: logger,
 	}
 	config = config.WithDynamoClient(dc)
-	c := NewClient(config, 0)
+	c := NewClient(config)
 	err := c.Init(context.Background())
 	must.ErrorIs(t, err, ErrInvalidConfiguration)
 }
@@ -57,7 +57,7 @@ func TestInit_ReserveShard(t *testing.T) {
 		},
 	}, nil)
 	config := testConfig().WithDynamoClient(dc)
-	c := NewClient(config, 0)
+	c := NewClient(config)
 	must.Nil(t, c.reservation)
 	err := c.Init(ctx)
 	must.NoError(t, err)
@@ -138,7 +138,7 @@ func TestReserveShard(t *testing.T) {
 
 			dc := mocks.NewDynamoDBAPI(t)
 			dc.EXPECT().UpdateItem(ctx, input).Return(tc.out, tc.err).Once()
-			m := NewClient(config.WithDynamoClient(dc), 0)
+			m := NewClient(config.WithDynamoClient(dc))
 			err := m.ReserveShard(ctx)
 			if tc.expectedError == nil {
 				must.NoError(t, err)
@@ -154,7 +154,7 @@ func TestReleaseReservation(t *testing.T) {
 	ctx := context.Background()
 	dc := mocks.NewDynamoDBAPI(t)
 	config := testConfig().WithDynamoClient(dc)
-	m := NewClient(config, 0)
+	m := NewClient(config)
 	input := &dynamodb.UpdateItemInput{
 		TableName: &config.ReservationTable,
 		Key: map[string]types.AttributeValue{
@@ -181,7 +181,7 @@ func TestReleaseReservation_Error(t *testing.T) {
 	ctx := context.Background()
 	dc := mocks.NewDynamoDBAPI(t)
 	config := testConfig().WithDynamoClient(dc)
-	m := NewClient(config, 0)
+	m := NewClient(config)
 	input := &dynamodb.UpdateItemInput{
 		TableName: &config.ReservationTable,
 		Key: map[string]types.AttributeValue{
@@ -325,9 +325,9 @@ func TestRetrieveRandomShardID(t *testing.T) {
 		must.True(t, t.Run(tc.name, func(t *testing.T) {
 			dc := mocks.NewDynamoDBAPI(t)
 			kc := mocks.NewKinesisAPI(t)
-			config := testConfig().WithDynamoClient(dc).WithKinesisClient(kc)
+			config := testConfig().WithDynamoClient(dc).WithKinesisClient(kc).WithSeed(tc.offset)
 			tc.setup(dc, kc)
-			m := NewClient(config, tc.offset)
+			m := NewClient(config)
 			s, err := m.retrieveRandomShardID(ctx)
 			must.Eq(t, tc.err, err)
 			must.Eq(t, tc.shard, s)


### PR DESCRIPTION
Cleaning up the base client and moving the seed int into the config instead of a top level attribute